### PR TITLE
fix(active-index): resets index if activeIndex doesn't exist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/react-gallery",
-  "version": "1.0.2",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/react-gallery",
-      "version": "1.0.2",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "prop-types": "~15.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-gallery",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A customizable, accessible gallery component for React projects.",
   "files": [
     "dist"

--- a/src/lib/components/gallery-context.jsx
+++ b/src/lib/components/gallery-context.jsx
@@ -1,6 +1,6 @@
 // packages
 import PropTypes from "prop-types"
-import { createContext, useCallback, useRef, useState } from "react"
+import { createContext, useCallback, useRef, useState, useEffect } from "react"
 
 // utils
 import classnames from "../utils/classnames"
@@ -74,14 +74,26 @@ export const Gallery = ({
 
   const goToIndex = useCallback(
     (index) => {
+      const validatedIndex = !items[index] ? 0 : index
+
       setPreviouslyActiveIndex(activeIndex)
 
-      setActiveIndex(index)
-      const direction = index - activeIndex > 0 ? 1 : 0
-      if (onChange) onChange({ oldIndex: activeIndex, newIndex: index, direction })
+      setActiveIndex(validatedIndex)
+      const direction = validatedIndex - activeIndex > 0 ? 1 : 0
+      if (onChange)
+        onChange({ oldIndex: activeIndex, newIndex: validatedIndex, direction })
     },
-    [activeIndex, onChange]
+    [activeIndex, onChange, items]
   )
+
+  // This useEffect checks to see if the gallery item (index) exists, and if it
+  // doesn't it resets the gallery to the first slide (0). The edge case here
+  // becomes apparent when or if the length of gallery items changes, for instance
+  // separating/grouping items based on screen size.
+
+  useEffect(() => {
+    if (!items[activeIndex]) goToIndex()
+  }, [activeIndex, items, goToIndex])
 
   const value = {
     galleryItems: items,

--- a/src/lib/components/gallery-main.jsx
+++ b/src/lib/components/gallery-main.jsx
@@ -1,6 +1,6 @@
 // packages
 import PropTypes from "prop-types"
-import { useCallback, useEffect } from "react"
+import { useCallback } from "react"
 
 // hooks
 import { useGallery } from "../hooks/use-gallery"
@@ -18,12 +18,7 @@ export const GalleryMain = ({ renderGalleryItem, className, ...props }) => {
     touchState,
     setTouchState,
     swipeThreshold,
-    goToIndex,
   } = useGallery()
-
-  useEffect(() => {
-    if (!galleryItems[activeIndex]) goToIndex(0)
-  }, [activeIndex, galleryItems, goToIndex])
 
   const handlePointerDown = useCallback(() => {
     if (!draggable) return

--- a/src/lib/components/gallery-main.jsx
+++ b/src/lib/components/gallery-main.jsx
@@ -1,6 +1,6 @@
 // packages
 import PropTypes from "prop-types"
-import { useCallback } from "react"
+import { useCallback, useEffect } from "react"
 
 // hooks
 import { useGallery } from "../hooks/use-gallery"
@@ -18,7 +18,12 @@ export const GalleryMain = ({ renderGalleryItem, className, ...props }) => {
     touchState,
     setTouchState,
     swipeThreshold,
+    goToIndex,
   } = useGallery()
+
+  useEffect(() => {
+    if (!galleryItems[activeIndex]) goToIndex(0)
+  }, [activeIndex, galleryItems, goToIndex])
 
   const handlePointerDown = useCallback(() => {
     if (!draggable) return


### PR DESCRIPTION
## Description

We discovered an edge case where the `activeIndex` did **not** exist. This often happens if the amount of `GalleryItems` changes based on the viewport width.

## Solution

Adds a check to see if the activeIndex exists, if it doesn't run the `goToIndex()` function and default to 0.

## Note

Fixes #3 
