### PR TITLE
feat(PaginationItem): Expose the gallery-pagination-item component

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,18 +228,14 @@ This render prop is a nice alternative to simply passing childern to the `<Galle
 
 Renders an unordered list (`<ul>`) of pagination items. Must be used within a `<Gallery>`.
 
-*Note: The use of renderPaginationItem is deprecated. [&lt;GalleryPaginationItem&gt;](#gallerypaginationitem) and `children` render props should be used here. This is still availiable to prevent breaking changes.*
-
 #### Props:
 
 | Prop                 | Type     | Description                                                                                                           |
 | -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
 | className            | String   |                                                                                                                       |
-| children             | JSX      | Pass children or use `<GalleryPaginationItem />` component to render pagination item buttons. This also is a render prop that will return some values to use [More information](#renderpaginationitem) below. |
-| renderPaginationItem *(deprecated)* | Function | A render prop, returning the JSX to render for each pagination item. [More information](#renderpaginationitem) below. |
+| renderPaginationItem | Function | A render prop, returning the JSX to render for each pagination item. [More information](#renderpaginationitem) below. |
 
-#### `renderPaginationItem`,
-#### `children` render props
+#### `renderPaginationItem`
 
 This render prop wraps its return value in a list item (`<li>`) and a `<button>`, and receives a handful of arguments:
 
@@ -247,21 +243,18 @@ This render prop wraps its return value in a list item (`<li>`) and a `<button>`
 | ----------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
 | active      | Boolean | Whether the current pagination item being iterated over corresponds to the active gallery item.                           |
 | activeIndex | Number  | The index of the currently active gallery item.                                                                           |
-| i *(deprecated)* | Number  | The index of the current pagination item being iterated over.                                                        |
-| index       | Number  | Same as the depreacted `i` The index of the current pagination item being iterated over.                                  |
+| index       | Number  | The index of the current pagination item being iterated over.                                  |
 | item        | Any     | The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop. |
 
 **Example usage of `children` render props**
 ```jsx
-<GalleryPagination>
-  {({ index, active, activeIndex, item }) => {
-    return (
-      <GalleryPaginationItem active={active}>
-        <span>{index + 1}</span>
-      </GalleryPaginationItem>
-    )
-  }}
-</GalleryPagination>
+<GalleryPagination
+  renderPaginationItem={({ index, active }) => (
+    <GalleryPaginationItem index={index} active={active} key={index}>
+      <span>{index + 1}</span>
+    </GalleryPaginationItem>
+  )}
+/>
 ```
 ### &lt;GalleryPaginationItem&gt;
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ This render prop wraps its return value in a list item (`<li>`) and a `<button>`
 | index       | Number  | The index of the current pagination item being iterated over.                                  |
 | item        | Any     | The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop. |
 
-**Example usage of `children` render props**
+**Example usage of `renderPaginationItem` render props**
 ```jsx
 <GalleryPagination
   renderPaginationItem={({ index, active }) => (
@@ -258,7 +258,7 @@ This render prop wraps its return value in a list item (`<li>`) and a `<button>`
 ```
 ### &lt;GalleryPaginationItem&gt;
 
-Used as children for `<GalleryPagination>`. This component with a return value in a list item (`<li>`) and a `<button>`, and receives a handful of arguments:
+Used in the prop `renderPaginationItem` of `<GalleryPagination>`. This component with a return value in a list item (`<li>`) and a `<button>`, and receives a handful of arguments:
 
 #### Props:
 
@@ -270,8 +270,23 @@ Used as children for `<GalleryPagination>`. This component with a return value i
 | buttonProps        | Object   | Pass props to the `<button>` element.                                                                           |
 | children           | JSX      | Pass children to the component to render them as children of the implicit `<button>` element.                     |
 | className          | String   | Set the `<li>` element's class.                                                                                  |
-| index              | Number   | This needs to be a unique key for the `<li>` element. Used to set the gallery's active item to the associated pagination item button clicked/ |
-| onClick            | Function | Callback function to hook into the `onClick` handler on the `<button>` element.                                 |
+| index              | Number   | This needs to be a unique identifier for the `<li>` element. Used to set the gallery's active item to the associated pagination item button clicked. |
+| onClick            | Function | This is a curried callback function to hook into the `onClick` handler on the `<button>` element. The curried callback returns an object containing `{event,index}`. `event` is a `MouseClickEvent` and `index` is the index of the *PaginationItem*.                                 |
+
+**Example usage of `onClick` render props**
+```jsx
+const handlePaginationItemClick = ({event, index}) => {
+  console.log(event, index)
+}
+
+<GalleryPagination
+  renderPaginationItem={({ index, active }) => (
+    <GalleryPaginationItem index={index} active={active} key={index} onClick={handlePaginationItemClick}>
+      <span>{index + 1}</span>
+    </GalleryPaginationItem>
+  )}
+/>
+```
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ export const GALLERY_ITEMS = [
 // your-gallery.js
 
 import { GALLERY_ITEMS } from "./some-data"
-import { Gallery, GalleryMain, GalleryNav, GalleryPagination, GalleryItem } from "@wethegit/react-gallery"
+import { Gallery,
+  GalleryMain,
+  GalleryNav,
+  GalleryPagination,
+  GalleryPaginationItem,
+  GalleryItem,
+} from "@wethegit/react-gallery"
 
 const YourGallery = () => {
   return (
@@ -86,7 +92,7 @@ const YourGallery = () => {
 
       <GalleryMain
         renderGalleryItem={({ item, i, active }) => (
-          <GalleryItem key={i} index={i} active={active}>
+          <GalleryItem key={item.id} index={i} active={active}>
             <img src={item.image} alt={item.alt} />
           </GalleryItem>
         )}
@@ -96,8 +102,10 @@ const YourGallery = () => {
       <GalleryNav direction={1}>➡️</GalleryNav>
 
       <GalleryPagination
-        renderPaginationItem={({ i }) => (
-          <span>{i + 1}</span>
+        renderPaginationItem={({ item, index, active }) => (
+          <GalleryPaginationItem key={item.id} index={index} active={active}>
+            <span>{i + 1}</span>
+          </GalleryPaginationItem>
         )}
       />
 
@@ -114,7 +122,7 @@ The first step is to give your data to the `<Gallery>` component via the `items`
 
 We're using the `<GalleryNav>` component to define our "next" and "previous" buttons. These components receive a `direction` prop, which expects either a `1` or a `0`, and corresponds to the direction the gallery should move in when the button in question is clicked (where `0` maps to "previous", and `1` maps to "next"). For a detailed breakdown of this component, see the [GalleryNav](#gallerynav) section.
 
-We're also using the `<GalleryPagination>` component here. If you're not familiar, "pagination" refers to what is often rendered as a set of "dots" below a gallery — but this can be _anything_ (thumbnails, icons, and so on). This component receives the render prop, `renderPaginationItem`, which exposes a few arguments you can use in the JSX you return: `item`, `i`, `activeIndex`, and `active`. For a detailed breakdown of this component, jump ahead to the [GalleryPagination](#gallerypagination) section.
+We're also using the `<GalleryPagination>` and `GalleryPaginationItem` components here. If you're not familiar, "pagination" refers to what is often rendered as a set of "dots" below a gallery — but this can be _anything_ (thumbnails, icons, and so on). This component receives the render prop, `renderPaginationItem`, which exposes a few arguments you can use in the JSX you return: `item`, `i`, `activeIndex`, and `active`. The easiest way to link up you pagination is to use the `<GalleryPaginationItem>` component, as shown in the example above. For a detailed breakdown of this component, jump ahead to the [GalleryPagination](#gallerypagination) section.
 
 ## Custom layouts
 
@@ -237,7 +245,7 @@ Renders an unordered list (`<ul>`) of pagination items. Must be used within a `<
 
 #### `renderPaginationItem`
 
-This render prop wraps its return value in a list item (`<li>`) and a `<button>`, and receives a handful of arguments:
+This render prop receives a handful of arguments, and is necessary for rendering pagination UI:
 
 | Argument    | Type    | Description                                                                                                               |
 | ----------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
@@ -246,11 +254,11 @@ This render prop wraps its return value in a list item (`<li>`) and a `<button>`
 | index       | Number  | The index of the current pagination item being iterated over.                                  |
 | item        | Any     | The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop. |
 
-**Example usage of `renderPaginationItem` render props**
+**Example usage of `renderPaginationItem` render prop**
 ```jsx
 <GalleryPagination
-  renderPaginationItem={({ index, active }) => (
-    <GalleryPaginationItem index={index} active={active} key={index}>
+  renderPaginationItem={({ index, active, activeIndex, item }) => (
+    <GalleryPaginationItem index={index} active={active} key={item.id}>
       <span>{index + 1}</span>
     </GalleryPaginationItem>
   )}
@@ -265,23 +273,28 @@ Used in the prop `renderPaginationItem` of `<GalleryPagination>`. This component
 
 | Prop               | Type     | Description                                                                                                     |
 | ------------------ | -------- | --------------------------------------------------------------------------------------------------------------- |
-| active             | Boolean  | Boolean to set the `<button>`'s `aria-current` attribute.                                                       |
+| active             | Boolean  | **Required**. Boolean to set the `<button>`'s `aria-current` attribute.                                                       |
 | buttonClassName    | String   | Set the `<button>` element's class.                                                                             |
 | buttonProps        | Object   | Pass props to the `<button>` element.                                                                           |
 | children           | JSX      | Pass children to the component to render them as children of the implicit `<button>` element.                     |
 | className          | String   | Set the `<li>` element's class.                                                                                  |
-| index              | Number   | This needs to be a unique identifier for the `<li>` element. Used to set the gallery's active item to the associated pagination item button clicked. |
+| index              | Number   | **Required**. This needs to be a unique identifier for the `<li>` element, corresponding to the index of the Gallery Item being iterated over. It is used to set the gallery's active item to the associated pagination item button clicked. |
 | onClick            | Function | This is a curried callback function to hook into the `onClick` handler on the `<button>` element. The curried callback returns an object containing `{event,index}`. `event` is a `MouseClickEvent` and `index` is the index of the *PaginationItem*.                                 |
 
-**Example usage of `onClick` render props**
+**Example usage of `onClick` prop**
 ```jsx
-const handlePaginationItemClick = ({event, index}) => {
+const handlePaginationItemClick = ({ event, index }) => {
   console.log(event, index)
 }
 
 <GalleryPagination
-  renderPaginationItem={({ index, active }) => (
-    <GalleryPaginationItem index={index} active={active} key={index} onClick={handlePaginationItemClick}>
+  renderPaginationItem={({ index, active, item }) => (
+    <GalleryPaginationItem
+      index={index}
+      active={active}
+      key={item.id}
+      onClick={handlePaginationItemClick}
+    >
       <span>{index + 1}</span>
     </GalleryPaginationItem>
   )}
@@ -316,9 +329,13 @@ const YourGallery = () => {
     // Pass the style overrides to the <Gallery> component
     <Gallery items={GALLERY_ITEMS} style={style}>
       <GalleryMain
-        renderGalleryItem={({ item }) => <img src={item.image} alt={item.alt} />}
+        renderGalleryItem={({ item, i, active }) => (
+          <GalleryItem key={item.id} index={i} active={active}>
+            <img src={item.image} alt={item.alt} />
+          </GalleryItem>
+        )}
       />
-      // ...etc
+      {/* ...etc */}
     </Gallery>
   )
 }
@@ -326,7 +343,8 @@ const YourGallery = () => {
 
 ## useGallery hook
 
-The gallery package exposes a `useGallery` React hook. It returns a single object, the properties of which are outlined below:
+The gallery package exposes a `useGallery` React hook. It returns a single object, the properties of which are outlined below.  
+⚠️ `useGallery` _must_ be called from within a `<Gallery>` context.
 
 | Property                 | Type      | Description                                                                                                                                                                                  |
 | ------------------------ | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -228,14 +228,18 @@ This render prop is a nice alternative to simply passing childern to the `<Galle
 
 Renders an unordered list (`<ul>`) of pagination items. Must be used within a `<Gallery>`.
 
+*Note: The use of renderPaginationItem is deprecated. [&lt;GalleryPaginationItem&gt;](#gallerypaginationitem) and `children` render props should be used here. This is still availiable to prevent breaking changes.*
+
 #### Props:
 
 | Prop                 | Type     | Description                                                                                                           |
 | -------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
 | className            | String   |                                                                                                                       |
-| renderPaginationItem | Function | A render prop, returning the JSX to render for each pagination item. [More information](#renderpaginationitem) below. |
+| children             | JSX      | Pass children or use `<GalleryPaginationItem />` component to render pagination item buttons. This also is a render prop that will return some values to use [More information](#renderpaginationitem) below. |
+| renderPaginationItem *(deprecated)* | Function | A render prop, returning the JSX to render for each pagination item. [More information](#renderpaginationitem) below. |
 
-#### `renderPaginationItem`
+#### `renderPaginationItem`,
+#### `children` render props
 
 This render prop wraps its return value in a list item (`<li>`) and a `<button>`, and receives a handful of arguments:
 
@@ -243,8 +247,38 @@ This render prop wraps its return value in a list item (`<li>`) and a `<button>`
 | ----------- | ------- | ------------------------------------------------------------------------------------------------------------------------- |
 | active      | Boolean | Whether the current pagination item being iterated over corresponds to the active gallery item.                           |
 | activeIndex | Number  | The index of the currently active gallery item.                                                                           |
-| i           | Number  | The index of the current pagination item being iterated over.                                                             |
+| i *(deprecated)* | Number  | The index of the current pagination item being iterated over.                                                        |
+| index       | Number  | Same as the depreacted `i` The index of the current pagination item being iterated over.                                  |
 | item        | Any     | The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop. |
+
+**Example usage of `children` render props**
+```jsx
+<GalleryPagination>
+  {({ index, active, activeIndex, item }) => {
+    return (
+      <GalleryPaginationItem active={active}>
+        <span>{index + 1}</span>
+      </GalleryPaginationItem>
+    )
+  }}
+</GalleryPagination>
+```
+### &lt;GalleryPaginationItem&gt;
+
+Used as children for `<GalleryPagination>`. This component with a return value in a list item (`<li>`) and a `<button>`, and receives a handful of arguments:
+
+#### Props:
+
+
+| Prop               | Type     | Description                                                                                                     |
+| ------------------ | -------- | --------------------------------------------------------------------------------------------------------------- |
+| active             | Boolean  | Boolean to set the `<button>`'s `aria-current` attribute.                                                       |
+| buttonClassName    | String   | Set the `<button>` element's class.                                                                             |
+| buttonProps        | Object   | Pass props to the `<button>` element.                                                                           |
+| children           | JSX      | Pass children to the component to render them as children of the implicit `<button>` element.                     |
+| className          | String   | Set the `<li>` element's class.                                                                                  |
+| index              | Number   | This needs to be a unique key for the `<li>` element. Used to set the gallery's active item to the associated pagination item button clicked/ |
+| onClick            | Function | Callback function to hook into the `onClick` handler on the `<button>` element.                                 |
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ const YourGallery = () => {
     <Gallery items={GALLERY_ITEMS}>
 
       <GalleryMain
-        renderGalleryItem={({ item, i, active }) => (
+        renderGalleryItem={({ item, index, active }) => (
           <GalleryItem key={item.id} index={i} active={active}>
             <img src={item.image} alt={item.alt} />
           </GalleryItem>
@@ -118,7 +118,7 @@ export default YourGallery
 
 The first step is to give your data to the `<Gallery>` component via the `items` prop. At the very least, `items` is expected to be an Array. From there, you're free to arrange the child components this package provides as you see fit. Below is a brief description of each of the child components' usage. For a detailed breakdown of this component, jump ahead to the [Gallery](#gallery) section.
 
-`<GalleryMain>` is the primary gallery view where your item data is rendered. It receives a render prop, `renderGalleryItem`, which exposes a few arguments you can use in the JSX you return: `item`, `i`, `activeIndex`, and `active` and expects a `<GalleryItem>` to be returned. For a detailed breakdown of this component, jump ahead to the [GalleryMain](#gallerymain) section.
+`<GalleryMain>` is the primary gallery view where your item data is rendered. It receives a render prop, `renderGalleryItem`, which exposes a few arguments you can use in the JSX you return: `item`, `index`, `activeIndex`, and `active` and expects a `<GalleryItem>` to be returned. For a detailed breakdown of this component, jump ahead to the [GalleryMain](#gallerymain) section.
 
 We're using the `<GalleryNav>` component to define our "next" and "previous" buttons. These components receive a `direction` prop, which expects either a `1` or a `0`, and corresponds to the direction the gallery should move in when the button in question is clicked (where `0` maps to "previous", and `1` maps to "next"). For a detailed breakdown of this component, see the [GalleryNav](#gallerynav) section.
 
@@ -196,7 +196,7 @@ This render prop expects a `<GalleryItem>` to be returned, and receives a handfu
 | ----------- | ------- | -------------------------------------------------------------------------------------------------------------- |
 | active      | Boolean | Whether the current item being iterated over is the active item.                                               |
 | activeIndex | Number  | The index of the currently active gallery item.                                                                |
-| i           | Number  | The index of the current item being iterated over.                                                             |
+| index       | Number  | The index of the current item being iterated over.                                                             |
 | item        | Any     | The current item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop. |
 
 ### &lt;GalleryItem&gt;
@@ -279,7 +279,7 @@ Used in the prop `renderPaginationItem` of `<GalleryPagination>`. This component
 | children           | JSX      | Pass children to the component to render them as children of the implicit `<button>` element.                     |
 | className          | String   | Set the `<li>` element's class.                                                                                  |
 | index              | Number   | **Required**. This needs to be a unique identifier for the `<li>` element, corresponding to the index of the Gallery Item being iterated over. It is used to set the gallery's active item to the associated pagination item button clicked. |
-| onClick            | Function | This is a curried callback function to hook into the `onClick` handler on the `<button>` element. The curried callback returns an object containing `{event,index}`. `event` is a `MouseClickEvent` and `index` is the index of the *PaginationItem*.                                 |
+| onClick            | Function | This is a curried callback function to hook into the `onClick` handler on the `<button>` element. The curried callback returns an object containing `{event,index}`. `event` is a `MouseClickEvent` and `index` is the index of the *PaginationItem*. Note that this is specific to the pagination buttons; if you want a piece of code to run when the active item changes _regarless_ of what triggered that change, opt for the `onChange` callback instead (passed to the `<Gallery>` component.)                                |
 
 **Example usage of `onClick` prop**
 ```jsx
@@ -329,8 +329,8 @@ const YourGallery = () => {
     // Pass the style overrides to the <Gallery> component
     <Gallery items={GALLERY_ITEMS} style={style}>
       <GalleryMain
-        renderGalleryItem={({ item, i, active }) => (
-          <GalleryItem key={item.id} index={i} active={active}>
+        renderGalleryItem={({ item, index, active }) => (
+          <GalleryItem key={item.id} index={index} active={active}>
             <img src={item.image} alt={item.alt} />
           </GalleryItem>
         )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/react-gallery",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/react-gallery",
-      "version": "2.0.1",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "prop-types": "~15.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-gallery",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "A customizable, accessible gallery component for React projects.",
   "files": [
     "dist"

--- a/src/lib/components/gallery-main.jsx
+++ b/src/lib/components/gallery-main.jsx
@@ -129,9 +129,9 @@ export const GalleryMain = ({ renderGalleryItem, className, ...props }) => {
       style={{ "--selected": activeIndex, "--total": galleryItems.length }}
       {...props}
     >
-      {galleryItems.map((item, i) => {
-        const active = activeIndex === i
-        return renderGalleryItem({ item, i, activeIndex, active })
+      {galleryItems.map((item, index) => {
+        const active = activeIndex === index
+        return renderGalleryItem({ item, index, activeIndex, active })
       })}
     </ul>
   )

--- a/src/lib/components/gallery-pagination-item.jsx
+++ b/src/lib/components/gallery-pagination-item.jsx
@@ -22,15 +22,11 @@ export const GalleryPaginationItem = ({
   const handleClick = (i) => (event) => {
     goToIndex(i)
     itemNodes.current[i].focus({ preventScroll: true })
-    onClick && onClick({ event, index })
+    onClick?.({ event, index })
   }
 
   return (
-    <li
-      key={index}
-      className={classnames(["gallery__pagination-item", className])}
-      {...props}
-    >
+    <li className={classnames(["gallery__pagination-item", className])} {...props}>
       <button
         className={buttonClassName}
         onClick={handleClick(index)}

--- a/src/lib/components/gallery-pagination-item.jsx
+++ b/src/lib/components/gallery-pagination-item.jsx
@@ -11,19 +11,32 @@ export const GalleryPaginationItem = ({
   index,
   active,
   className,
+  buttonClassName,
+  buttonProps,
   children,
+  onClick,
   ...props
 }) => {
   const { goToIndex, itemNodes } = useGallery()
 
-  const handleClick = (i) => {
+  const handleClick = (i) => (event) => {
     goToIndex(i)
     itemNodes.current[i].focus({ preventScroll: true })
+    onClick && onClick({ event, index })
   }
 
   return (
-    <li className={classnames(["gallery__pagination-item", className])} {...props}>
-      <button onClick={() => handleClick(index)} aria-current={active ? "true" : null}>
+    <li
+      key={index}
+      className={classnames(["gallery__pagination-item", className])}
+      {...props}
+    >
+      <button
+        className={buttonClassName}
+        onClick={handleClick(index)}
+        aria-current={active ? "true" : null}
+        {...buttonProps}
+      >
         {children}
       </button>
     </li>
@@ -34,5 +47,8 @@ GalleryPaginationItem.propTypes = {
   index: PropTypes.number.isRequired,
   active: PropTypes.bool.isRequired,
   className: PropTypes.string,
+  buttonClassName: PropTypes.string,
+  buttonProps: PropTypes.object,
   children: PropTypes.node,
+  onClick: PropTypes.func,
 }

--- a/src/lib/components/gallery-pagination.jsx
+++ b/src/lib/components/gallery-pagination.jsx
@@ -4,9 +4,6 @@ import PropTypes from "prop-types"
 // hooks
 import { useGallery } from "../hooks/use-gallery"
 
-// components
-import { GalleryPaginationItem } from "./gallery-pagination-item"
-
 // utils
 import classnames from "../utils/classnames"
 
@@ -14,45 +11,42 @@ import classnames from "../utils/classnames"
  *
  * Pagination Item
  * ---
- * Children Render Props example
+ * @typedef {element} renderPaginationItem - Expects a component of GallerPaginationItem
  * @returns {index, active, activeIndex, item}
- * @deprecated renderPaginationItem
  *
- * @param {number} index - The index of the current pagination item being iterated over.
- * @param {boolean} active - Whether the current pagination item being iterated over corresponds to the active gallery item.
- * @param {number} activeIndex - The index of the currently active gallery item.
- * @param {object} item - The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop.
- *
+ * @property {number} index - The index of the current pagination item being iterated over.
+ * @property {boolean} active - Whether the current pagination item being iterated over corresponds to the active gallery item.
+ * @property {number} activeIndex - The index of the currently active gallery item.
+ * @property {object} item - The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop.
  */
 
-export const GalleryPagination = ({
-  renderPaginationItem,
-  className,
-  children = renderPaginationItem,
-  ...props
-}) => {
+/**
+ * Displays a greeting to the user.
+ * @param {Props} renderPaginationItem
+ * @param {string} className
+ * @example
+ *  <GalleryPagination
+ *    renderPaginationItem={({ index, active }) => (
+ *      <GalleryPaginationItem index={index} active={active} key={index}>
+ *        <span>{index + 1}</span>
+ *      </GalleryPaginationItem>
+ *    )}
+ *  />
+ */
+export const GalleryPagination = ({ renderPaginationItem, className, ...props }) => {
   const { activeIndex, galleryItems } = useGallery()
 
   return (
     <ul className={classnames(["gallery__pagination", className])} {...props}>
       {galleryItems.map((item, index) => {
         const active = activeIndex === index
-
-        // This conditional is to support legacy implimentations of this library.
-        return renderPaginationItem ? (
-          <GalleryPaginationItem index={index} active={active} key={index}>
-            {renderPaginationItem({ item, i: index, activeIndex, active })}
-          </GalleryPaginationItem>
-        ) : (
-          children({ index, active, activeIndex, item })
-        )
+        return renderPaginationItem({ index, active, activeIndex, item })
       })}
     </ul>
   )
 }
 
 GalleryPagination.propTypes = {
-  renderPaginationItem: PropTypes.func,
+  renderPaginationItem: PropTypes.func.isRequired,
   className: PropTypes.string,
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
 }

--- a/src/lib/components/gallery-pagination.jsx
+++ b/src/lib/components/gallery-pagination.jsx
@@ -9,21 +9,21 @@ import classnames from "../utils/classnames"
 
 /***
  *
- * Pagination Item
+ * Pagination Item component callback
  * ---
- * @typedef {element} renderPaginationItem - Expects a component of GallerPaginationItem
- * @returns {index, active, activeIndex, item}
- *
- * @property {number} index - The index of the current pagination item being iterated over.
- * @property {boolean} active - Whether the current pagination item being iterated over corresponds to the active gallery item.
- * @property {number} activeIndex - The index of the currently active gallery item.
- * @property {object} item - The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop.
+ * @callback renderPaginationItem - Expects a component of GalleryPaginationItem
+ * @param {number} index - The index of the current pagination item being iterated over.
+ * @param {boolean} active - Whether the current pagination item being iterated over corresponds to the active gallery item.
+ * @param {number} activeIndex - The index of the currently active gallery item.
+ * @param {object} item - The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop.
  */
 
 /**
- * Displays a greeting to the user.
- * @param {Props} renderPaginationItem
- * @param {string} className
+ * Pagination Component
+ * ---
+ * @param {object} props
+ * @param {renderPaginationItem} props.renderPaginationItem - The component to be rendered. This expects the main wrapper to be a GalleryPaginationItem component
+ * @param {string} [props.className] - Pass classname to <ul> element
  * @example
  *  <GalleryPagination
  *    renderPaginationItem={({ index, active }) => (

--- a/src/lib/components/gallery-pagination.jsx
+++ b/src/lib/components/gallery-pagination.jsx
@@ -10,17 +10,41 @@ import { GalleryPaginationItem } from "./gallery-pagination-item"
 // utils
 import classnames from "../utils/classnames"
 
-export const GalleryPagination = ({ renderPaginationItem, className, ...props }) => {
+/***
+ *
+ * Pagination Item
+ * ---
+ * Children Render Props example
+ * @returns {index, active, activeIndex, item}
+ * @deprecated renderPaginationItem
+ *
+ * @param {number} index - The index of the current pagination item being iterated over.
+ * @param {boolean} active - Whether the current pagination item being iterated over corresponds to the active gallery item.
+ * @param {number} activeIndex - The index of the currently active gallery item.
+ * @param {object} item - The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop.
+ *
+ */
+
+export const GalleryPagination = ({
+  renderPaginationItem,
+  className,
+  children = renderPaginationItem,
+  ...props
+}) => {
   const { activeIndex, galleryItems } = useGallery()
 
   return (
     <ul className={classnames(["gallery__pagination", className])} {...props}>
-      {galleryItems.map((item, i) => {
-        const active = activeIndex === i
-        return (
-          <GalleryPaginationItem index={i} active={active} key={i}>
-            {renderPaginationItem({ item, i, activeIndex, active })}
+      {galleryItems.map((item, index) => {
+        const active = activeIndex === index
+
+        // This conditional is to support legacy implimentations of this library.
+        return renderPaginationItem ? (
+          <GalleryPaginationItem index={index} active={active} key={index}>
+            {renderPaginationItem({ item, i: index, activeIndex, active })}
           </GalleryPaginationItem>
+        ) : (
+          children({ index, active, activeIndex, item })
         )
       })}
     </ul>
@@ -28,6 +52,7 @@ export const GalleryPagination = ({ renderPaginationItem, className, ...props })
 }
 
 GalleryPagination.propTypes = {
-  renderPaginationItem: PropTypes.func.isRequired,
+  renderPaginationItem: PropTypes.func,
   className: PropTypes.string,
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
 }

--- a/src/lib/components/gallery-pagination.jsx
+++ b/src/lib/components/gallery-pagination.jsx
@@ -15,7 +15,7 @@ import classnames from "../utils/classnames"
  * @param {number} index - The index of the current pagination item being iterated over.
  * @param {boolean} active - Whether the current pagination item being iterated over corresponds to the active gallery item.
  * @param {number} activeIndex - The index of the currently active gallery item.
- * @param {object} item - The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop.
+ * @param {any} item - The current pagination item being iterated over, as defined by the Array fed to the `<Gallery>` component's `items` prop.
  */
 
 /**

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,6 +1,7 @@
 export { Gallery } from "./components/gallery-context"
 export { GalleryMain } from "./components/gallery-main"
 export { GalleryPagination } from "./components/gallery-pagination"
+export { GalleryPaginationItem } from "./components/gallery-pagination-item"
 export { GalleryNav } from "./components/gallery-nav"
 export { GalleryItem } from "./components/gallery-item"
 export { useGallery } from "./hooks/use-gallery"

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,6 +6,7 @@ import {
   GalleryItem,
   GalleryNav,
   GalleryPagination,
+  GalleryPaginationItem,
   useGallery,
 } from "./lib"
 
@@ -61,7 +62,20 @@ function App() {
       <GalleryNav direction={0}>⬅️</GalleryNav>
       <GalleryNav direction={1}>➡️</GalleryNav>
 
+      {/* Legacy Pagination Example
+       * <GalleryPagination renderPaginationItem={({ i }) => <span>{i + 1}</span>} />
+       */}
       <GalleryPagination renderPaginationItem={({ i }) => <span>{i + 1}</span>} />
+
+      <GalleryPagination>
+        {({ index, active }) => {
+          return (
+            <GalleryPaginationItem index={index} active={active}>
+              <span>{index + 1}</span>
+            </GalleryPaginationItem>
+          )
+        }}
+      </GalleryPagination>
       <GalleryDescription />
     </Gallery>
   )

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -57,8 +57,8 @@ function App() {
   return (
     <Gallery items={GALLERY_ITEMS}>
       <GalleryMain
-        renderGalleryItem={({ item, i, active }) => (
-          <GalleryItem key={i} index={i} active={active}>
+        renderGalleryItem={({ item, index, active }) => (
+          <GalleryItem key={item.id} index={index} active={active}>
             <img src={item.image} alt={item.alt} />
           </GalleryItem>
         )}
@@ -68,11 +68,11 @@ function App() {
       <GalleryNav direction={1}>➡️</GalleryNav>
 
       <GalleryPagination
-        renderPaginationItem={({ index, active }) => (
+        renderPaginationItem={({ index, active, item }) => (
           <GalleryPaginationItem
             index={index}
             active={active}
-            key={index}
+            key={item.id}
             onClick={handlePaginationItemClick}
           >
             <span>{index + 1}</span>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -62,20 +62,13 @@ function App() {
       <GalleryNav direction={0}>⬅️</GalleryNav>
       <GalleryNav direction={1}>➡️</GalleryNav>
 
-      {/* Legacy Pagination Example
-       * <GalleryPagination renderPaginationItem={({ i }) => <span>{i + 1}</span>} />
-       */}
-      <GalleryPagination renderPaginationItem={({ i }) => <span>{i + 1}</span>} />
-
-      <GalleryPagination>
-        {({ index, active }) => {
-          return (
-            <GalleryPaginationItem index={index} active={active}>
-              <span>{index + 1}</span>
-            </GalleryPaginationItem>
-          )
-        }}
-      </GalleryPagination>
+      <GalleryPagination
+        renderPaginationItem={({ index, active }) => (
+          <GalleryPaginationItem index={index} active={active} key={index}>
+            <span>{index + 1}</span>
+          </GalleryPaginationItem>
+        )}
+      />
       <GalleryDescription />
     </Gallery>
   )

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -49,6 +49,11 @@ function GalleryDescription() {
 }
 
 function App() {
+  // Example of custom onClick handler
+  const handlePaginationItemClick = ({ event, index }) => {
+    console.log(event, index)
+  }
+
   return (
     <Gallery items={GALLERY_ITEMS}>
       <GalleryMain
@@ -64,7 +69,12 @@ function App() {
 
       <GalleryPagination
         renderPaginationItem={({ index, active }) => (
-          <GalleryPaginationItem index={index} active={active} key={index}>
+          <GalleryPaginationItem
+            index={index}
+            active={active}
+            key={index}
+            onClick={handlePaginationItemClick}
+          >
             <span>{index + 1}</span>
           </GalleryPaginationItem>
         )}


### PR DESCRIPTION
## Description

A feature request to expose the Pagination Item render elements `<li>` and `<button>` to allow for easier styling and control.

## Solution
- Added a child render prop that returns `index`, `active`, `activeIndex`, and `item` props.
- Exported `<GalleryPaginationItem>` component
  - Added props `buttonClassname` and `buttonProps` to pass to `<button>` element
  - Added prop `onClick` and call `onClick` prop in the `handleClick()`

## Note
`renderPaginationItem` prop was retained and conditional is set to prevent breaking changes if the package is updated.

## TODO
- Document `onClick` callback

Existing issue mentioned: #7 
