### PR TITLE
fix(gallery-draggable): adds ternary to onPointer events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wethegit/react-gallery",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wethegit/react-gallery",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "prop-types": "~15.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wethegit/react-gallery",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A customizable, accessible gallery component for React projects.",
   "files": [
     "dist"

--- a/src/lib/components/gallery-main.jsx
+++ b/src/lib/components/gallery-main.jsx
@@ -123,9 +123,9 @@ export const GalleryMain = ({ renderGalleryItem, className, ...props }) => {
   return (
     <ul
       className={classnames(["gallery__main", className])}
-      onPointerDown={draggable && handlePointerDown}
-      onPointerMove={draggable && handlePointerMove}
-      onPointerUp={draggable && handlePointerUp}
+      onPointerDown={draggable ? handlePointerDown : null}
+      onPointerMove={draggable ? handlePointerMove : null}
+      onPointerUp={draggable ? handlePointerUp : null}
       style={{ "--selected": activeIndex, "--total": galleryItems.length }}
       {...props}
     >


### PR DESCRIPTION
## Description

Currently if a user sets draggable to `false` the gallery throws an error. 


## Solution

Previously the `onPointer` events added to `<Gallery />` didn't have a second argument so they would still run, even if false:

`onPointerDown={draggable && handlePointerDown}`

To prevent this, I've replaced the `&&` with a ternary operator and set the second result as `null`.

`onPointerDown={draggable ? handlePointerDown : null}`


## Screenshots

**Error**

<img width="1126" alt="Screenshot 2023-11-09 at 14 04 24" src="https://github.com/wethegit/react-gallery/assets/5969303/a10b9e8f-9385-434d-bfec-17f55f432591">



