### PR TITLE
fix: reset drag state on pointer leave to prevent stuck transitions

### DIFF
--- a/src/lib/components/gallery-main.jsx
+++ b/src/lib/components/gallery-main.jsx
@@ -119,12 +119,41 @@ export const GalleryMain = ({ renderGalleryItem, className, ...props }) => {
     previous,
   ])
 
+  const handlePointerLeave = useCallback(() => {
+    if (!draggable) return
+
+    if (touchState.isDragging) {
+      if (Math.abs(touchState.xOffset) > swipeThreshold) {
+        if (touchState.xOffset < 0) next()
+        else previous()
+      }
+
+      setTouchState((prevState) => ({
+        ...prevState,
+        isDragging: false,
+        xOffset: 0,
+        start: 0,
+        offsetting: false,
+        scrolling: false,
+      }))
+    }
+  }, [
+    draggable,
+    touchState.isDragging,
+    touchState.xOffset,
+    swipeThreshold,
+    setTouchState,
+    next,
+    previous,
+  ])
+
   return (
     <ul
       className={classnames([styles.gallery__main, className])}
       onPointerDown={draggable ? handlePointerDown : null}
       onPointerMove={draggable ? handlePointerMove : null}
       onPointerUp={draggable ? handlePointerUp : null}
+      onPointerLeave={draggable ? handlePointerLeave : null}
       style={{ "--selected": activeIndex, "--total": galleryItems.length }}
       {...props}
     >


### PR DESCRIPTION
## Problem
When the draggable prop is set to true and the pointer leaves the gallery area during a drag/swipe, the gallery gets stuck in an in-between state because the drag flags are never reset.

## Solution
Add an onPointerLeave handler to GalleryMain that mirrors the onPointerUp logic:
- Checks the current xOffset against swipeThreshold
- Transitions to the next/previous item if the threshold is exceeded
- Resets all touch state (isDragging, xOffset, start, offsetting, scrolling)

## Changes
- Added handlePointerLeave callback in gallery-main.jsx
- Wired it to the ul element onPointerLeave event

Closes #112