### PR TITLE
[RELEASE] Fix stale dist issue, bump to 4.0.5

### DIFF
--- a/.changeset/empty-boxes-remain.md
+++ b/.changeset/empty-boxes-remain.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/react-gallery": patch
+---
+
+Ensures that the `dist/` directory is removed before running a build. Users were seeing unwanted artifacts with conflicting React dependencies.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "prepare": "husky",
     "start": "vite",
+    "prebuild": "rm -rf dist",
     "build": "vite build",
     "lint:scripts": "eslint --fix --ext .jsx,js --ignore-path .gitignore .",
     "lint:styles": "stylelint src/**/*.{css,scss}",


### PR DESCRIPTION
Code review ticket: https://wethecollective.teamwork.com/app/tasks/22769488

This PR adds a `prebuild` script which removes the `dist/` directory, ensuring that it is never a cached version in the final tarball.

This fix was made after some feedback from users that ReactCurrentDispatcher was being included in the build output, causing React versioning conflicts, despite React being only a peer dependency.