### PR TITLE
[Fix] - Focus in Safari when the pressed nav button is disabled

### DIFF
--- a/.changeset/happy-days-brush.md
+++ b/.changeset/happy-days-brush.md
@@ -1,0 +1,5 @@
+---
+"@wethegit/react-gallery": patch
+---
+
+Fix the lost focus in Safari when the pressed nav button is disabled

--- a/src/lib/components/gallery-nav.jsx
+++ b/src/lib/components/gallery-nav.jsx
@@ -31,18 +31,15 @@ export const GalleryNav = ({
     "aria-disabled": shouldDisable ? "true" : null,
   }
 
+  if (!children && !renderNavItem) return null
+
   /*
-   * IFFE - avoiding use of useEffect
    * When the clicked/pressed button gets disabled, safari resets the focus
    * to the document, so we are redirecting the focus within the gallery
    */
-  ;(function handleLostFocus() {
-    if (shouldDisable) {
-      itemNodes.current[activeIndex]?.focus({ focusVisible: false })
-    }
-  })()
-
-  if (!children && !renderNavItem) return null
+  if (shouldDisable) {
+    itemNodes.current[activeIndex]?.focus({ focusVisible: false })
+  }
 
   return (
     <button

--- a/src/lib/components/gallery-nav.jsx
+++ b/src/lib/components/gallery-nav.jsx
@@ -12,7 +12,7 @@ export const GalleryNav = ({
   children,
   ...props
 }) => {
-  const { next, previous, loop, activeIndex, galleryItems } = useGallery()
+  const { next, previous, loop, activeIndex, galleryItems, itemNodes } = useGallery()
 
   const handleClick = () => {
     if (direction) next()
@@ -30,6 +30,17 @@ export const GalleryNav = ({
     disabled: shouldDisable ? true : null,
     "aria-disabled": shouldDisable ? "true" : null,
   }
+
+  /*
+   * IFFE - avoiding use of useEffect
+   * When the clicked/pressed button gets disabled, safari resets the focus
+   * to the document, so we are redirecting the focus within the gallery
+   */
+  ;(function handleLostFocus() {
+    if (shouldDisable) {
+      itemNodes.current[activeIndex]?.focus({ focusVisible: false })
+    }
+  })()
 
   if (!children && !renderNavItem) return null
 


### PR DESCRIPTION
Fixes #124 

I have used check, because the component re-renders already and is similar pattern to the current states used in that component. 